### PR TITLE
Use netconf4j feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.6</java.version>
 		<!-- dependencies versions -->
-		<netconf4j.version>0.0.6</netconf4j.version>
+		<netconf4j.version>0.0.7</netconf4j.version>
 		<pax-logging.version>1.6.10</pax-logging.version>
 		<commons-io.version>1.4</commons-io.version>
 		<sshd.version>0.9.0</sshd.version>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features>
+	<repository>mvn:net.i2cat.netconf/netconf4j/${netconf4j.version}/xml/features</repository>
+	
 	<feature name="netconf-server" version="${project.version}">
-		<bundle dependency="true">mvn:net.i2cat.netconf/netconf4j/${netconf4j.version}</bundle>
+		<feature version="${netconf4j.version}">netconf4j</feature>
 		<bundle dependency="true">mvn:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version}</bundle>
 		<bundle dependency="true">mvn:commons-io/commons-io/${commons-io.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.sshd/sshd-core/${sshd.version}</bundle>


### PR DESCRIPTION
netconf-server feature depends on netconf4j feature, instead of sole netconf4j bundle.

Netconf4j version updated to 0.0.7, as this is the first version where netconf4j is defined.
